### PR TITLE
#149 - Feature: Adicionar paginação de postagens à rota

### DIFF
--- a/backend/src/entities/post/post.controller.js
+++ b/backend/src/entities/post/post.controller.js
@@ -22,7 +22,7 @@ module.exports = {
         const distanceAttr = sequelize.fn(
           'ST_DistanceSphere',
           sequelize.literal('latlng'),
-          sequelize.literal(`ST_MakePoint(${longitude}, ${latitude})`)
+          sequelize.literal(`ST_MakePoint(${latitude}, ${longitude})`)
         );
 
         const { count, rows } = await Post.findAndCountAll({

--- a/frontend/src/Pages/ListPost/index.js
+++ b/frontend/src/Pages/ListPost/index.js
@@ -39,16 +39,15 @@ export default function ListPosts() {
   };
 
   const getPosts = async (filters) => {
-    try {
-      await api.get("/posts", { params: filters }).then(({ data }) => {
-        console.log("Posts recebidos da API:", data);
+    api.get("/posts", { params: filters })
+      .then(({ data }) => {
         setPosts(data.data);
         setPagination(data.pagination);
-      });
-    } catch (error) {
-      console.error("Erro ao obter posts:", error);
-      setPosts([]);
-    }
+      })
+      .catch((error) => {
+        console.error("Erro ao obter posts:", error);
+        setPosts([]);
+  });
   };
 
   useEffect(() => {
@@ -85,10 +84,10 @@ export default function ListPosts() {
           <span>nenhuma observação encontrada</span>
         )}
 
-        <div>
+        {/* <div>
           <p>Página {pagination.page} de {pagination.totalPages}</p>
           <p>Total de {pagination.totalElements} posts</p>
-        </div>
+        </div> */}
       </Container>
     </Layout>
   );


### PR DESCRIPTION
Funcionalidade de paginação para a rota de posts. A rota retornava todos os posts de uma vez, e agora ela é capaz de retornar posts paginados, assim o usuário pode lidar com um número maior de posts.

**Mudanças realizadas:**

- [x] Adição de paginação à rota de posts.

- [x] Implementação de parâmetros page e pageSize na consulta de posts.

- [x] Atualização da lógica do backend para calcular a quantidade total de páginas e de registros.

**Como testar:**

- [x] Fazer uma requisição para a rota de posts com os parâmetros page e pageSize (por exemplo: /posts?page=1&pageSize=10).

- [x] Verificar os posts retornados.